### PR TITLE
fix: End date with modified time, only if the start date has a greater time

### DIFF
--- a/src/Agenda/Weekly.php
+++ b/src/Agenda/Weekly.php
@@ -62,6 +62,24 @@ class Weekly implements AgendaInterface
         $start_date = $subject_period->start->clone();
         $end_date = $subject_period->end->clone();
 
+        /**
+         * The following allows the CarbonPeriod class to take into account the endDate if it has a time in H:i:s less than the starDate time:
+         *
+         * Example:
+         * Scenery -> Assigning the following schedule...
+         * SLASchedule::create()->from('08:00:00')->to('17:00:00')->everyDay()
+         *
+         * With the following dates:
+         * start_date = 2022-10-18 16:00:00 (Y-m-d H:i:s)
+         * now = 2022-10-19 08:00:01 (Y-m-d H:i:s)
+         *
+         * By not implementing this statement, CarbonPeriod may omit the end_date because the time on that day is less than the time on the start date. The value returned in this scenario would be 1 hour.
+         * With the following fix, CarbonPeriod will fully assume the end date but considering that the time to be evaluated must be within the range defined in the calendar
+         *
+         * The correct result is 1 hour and 1 second
+         */
+        $end_date = Carbon::parse($start_date->format('H:i:s'))->greaterThan($end_date->format('H:i:s')) ? $end_date->format('Y-m-d').'23:59:59' : $end_date;
+
         $new_period = CarbonPeriod::start($start_date)->end($end_date)->setDateInterval(CarbonInterval::day());
 
         return collect($new_period)

--- a/tests/SLATest.php
+++ b/tests/SLATest.php
@@ -118,7 +118,6 @@ it('tests that the percentage of fulfillment of an SLA is positive', function ()
     );
 
     testTime()->freeze($time_now);
-    print_r($sla->fulfillment($subject_start_time));
     expect($sla->fulfillment($subject_start_time))->toBeGreaterThan(50);    //66.666666666667%
 });
 
@@ -325,21 +324,20 @@ it('tests empty schedule', function () {
     expect($sla->duration($subject_start_time)->totalSeconds)->toEqual(0);
 });
 
-//it('tests 0 length SLAs', function () {
-//    $subject_start_time = '2022-07-21 08:59:00';
-//    $time_now = '2022-07-21 09:00:30';
-//
-//    $sla = SLA::fromSchedule(
-//        SLASchedule::create()->from('09:00:00')->to('17:00:00')
-//    );
-//
-//    testTime()->freeze($time_now);
-//
-//    expect($sla->duration($subject_start_time)->totalSeconds)->toEqual(30);
-//
-//    $sla->addSchedule(
-//        SLASchedule::create()->effectiveFrom('2022-07-20')->from('09:00:00')->to('09:00:01')->everyDay()
-//    );
-//
-//    expect($sla->duration($subject_start_time)->totalSeconds)->toEqual(1);
-//});
+it('test the SLA where the current date has a time less than the time of the initial date', function () {
+    $subject_start_time = '2022-10-18 16:00:00';
+    $time_now = '2022-10-19 08:00:01';
+
+    $sla = SLA::fromSchedule(
+        SLASchedule::create()->from('08:00:00')->to('17:00:00')->everyDay()
+    );
+
+    $sla->addBreaches(
+        new SLABreach('Time to First Response', '15m')
+    );
+
+    testTime()->freeze($time_now);
+    expect($sla->duration($subject_start_time)->totalSeconds)->toEqual(3601)
+        ->and(expect($sla->status($subject_start_time)->breaches)->toHaveCount(1))
+        ->and(expect($sla->status($subject_start_time)->breaches[0]->breached)->toEqual(true));
+});


### PR DESCRIPTION
CarbonPeriod class to take into account the endDate if it has a time in H:i:s less than the starDate time:

**Example:**
Scenery -> Assigning the following schedule...
SLASchedule::create()->from('08:00:00')->to('17:00:00')->everyDay()

With the following dates:
start_date = 2022-10-18 16:00:00 (Y-m-d H:i:s)
now = 2022-10-19 08:00:01 (Y-m-d H:i:s)

Without this fix, CarbonPeriod may omit the end_date because the time on that day is less than the time on the start date. The value returned in this scenario would be 1 hour.

Now, CarbonPeriod will fully assume the end date but considering that the time to be evaluated must be within the range defined in the calendar

The correct result is 1 hour and 1 second